### PR TITLE
Return 413 in case a packet is too large

### DIFF
--- a/include/internal.hrl
+++ b/include/internal.hrl
@@ -1,3 +1,3 @@
 
--define(RECBUF_SIZE, 8192).
-
+-define(RECBUF_SIZE, 16384).
+-define(RECBUF_LIMIT, ?RECBUF_SIZE / 2).


### PR DESCRIPTION
This pull-request address this issue: https://intranet.scrapinghub.com/issues/14674

This pull-request provides a solution to the problem in which mochiweb itself returns the status code 413 (please pay attention to the commit message).
I have another solution in mind, which is almost the same as this pull-request but the difference is, we should set a flag (let's say, for example, "too_large_packet" flag) or something so that we can catch it in Crawlera side, then Crawlera should decide what to do with the request.

Any ideas?