### PR TITLE
Export mochiweb_http:headers/5 and handle_invalid_request/1 functions

### DIFF
--- a/src/mochiweb_http.erl
+++ b/src/mochiweb_http.erl
@@ -7,6 +7,8 @@
 -author('bob@mochimedia.com').
 -export([start/1, start_link/1, stop/0, stop/1]).
 -export([loop/2]).
+-export([headers/5]).
+-export([handle_invalid_request/1]).
 -export([after_response/2, reentry/1]).
 -export([parse_range_request/1, range_skip_length/2]).
 


### PR DESCRIPTION
I need those two functions to be exported for supporting the `CONNECT` method.