### PR TITLE
headers reordering #35794

### DIFF
--- a/src/mochiweb_request.erl
+++ b/src/mochiweb_request.erl
@@ -294,12 +294,10 @@ format_response_header({Code, ResponseHeaders}) ->
                      false ->
                          HResponse1
                  end,
-    F = fun ({K, V}, Acc) ->
-                [mochiweb_util:make_io(K), <<": ">>, V, <<"\r\n">> | Acc]
-        end,
-    End = lists:foldl(F, [<<"\r\n">>], mochiweb_headers:to_list(HResponse2)),
+    End = [[mochiweb_util:make_io(K), <<": ">>, V, <<"\r\n">>]
+           || {K, V} <- mochiweb_headers:to_list(HResponse2)],
     Response = mochiweb:new_response({THIS, Code, HResponse2}),
-    {[make_version(Version), make_code(Code), <<"\r\n">> | End], Response};
+    {[make_version(Version), make_code(Code), <<"\r\n">> | [End, <<"\r\n">>]], Response};
 format_response_header({Code, ResponseHeaders, Length}) ->
     HResponse = mochiweb_headers:make(ResponseHeaders),
     HResponse1 = mochiweb_headers:enter("Content-Length", Length, HResponse),


### PR DESCRIPTION
We change the function to [format headers](https://github.com/mochi/mochiweb/blob/master/src/mochiweb_request.erl#L329) because of performance to:

        F = fun ({K, V}, Acc) ->
                [mochiweb_util:make_io(K), <<": ">>, V, <<"\r\n">> | Acc]
        end,

But this appends to the head, so a `reverse` is necessary to maintain headers order.

Example:

Headers list: 

    [
        {"Set-Cookie","selectedCountry=GB; Path=/; Domain=.johnlewis.com"},
        {"Set-Cookie","selectedCountry=DE; Path=/; Domain=.johnlewis.com"},
        {"X-Crawlera-Version","1.5.1-25-gcdc9f69"},
        {"x-crawlera-slave","localhost:59261"},
        {"date","Mon, 31 Aug 2015 23:43:04 GMT"},
        {"content-length","561"}
    ]

Previous Formatting:

    [
        "X-Crawlera-Version",<<": ">>,"1.5.1-25-gcdc9f69",<<"\r\n">>,
        "x-crawlera-slave",<<": ">>,"localhost:52280",<<"\r\n">>,
        "Set-Cookie",<<": ">>,"selectedCountry=DE; Path=/; Domain=.johnlewis.com",<<"\r\n">>,
        "Set-Cookie",<<": ">>,"selectedCountry=GB; Path=/; Domain=.johnlewis.com",<<"\r\n">>,
        "Proxy-Connection",<<": ">>,"close",<<"\r\n">>,
        "date",<<": ">>,"Mon, 31 Aug 2015 23:11:33 GMT",<<"\r\n">>,
        "content-length",<<": ">>,"561",<<"\r\n">>,
        "Connection",<<": ">>,"close",<<"\r\n">>,<<"\r\n">>
    ]

New Formatting:

    [
        "Connection",<<": ">>,"close",<<"\r\n">>,
        "content-length",<<": ">>,"561",<<"\r\n">>,
        "date",<<": ">>,"Mon, 31 Aug 2015 23:43:04 GMT",<<"\r\n">>,
        "Proxy-Connection",<<": ">>,"close",<<"\r\n">>,
        "Set-Cookie",<<": ">>,"selectedCountry=GB; Path=/; Domain=.johnlewis.com",<<"\r\n">>,
        "Set-Cookie",<<": ">>,"selectedCountry=DE; Path=/; Domain=.johnlewis.com",<<"\r\n">>,
        "x-crawlera-slave",<<": ">>,"localhost:59261",<<"\r\n">>,
        "X-Crawlera-Version",<<": ">>,"1.5.1-25-gcdc9f69",<<"\r\n">>,<<"\r\n">>
    ]

Let's remember that headers order doesn't matter for different names, while it does for headers with the same name according to [RFC 2616](http://tools.ietf.org/html/rfc2616):

> Multiple message-header fields with the same field-name MAY be
   present in a message if and only if the entire field-value for that
   header field is defined as a comma-separated list [i.e., #(values)].
   It MUST be possible to combine the multiple header fields into one
   "field-name: field-value" pair, without changing the semantics of the
   message, by appending each subsequent field-value to the first, each
   separated by a comma. The order in which header fields with the same
   field-name are received is therefore significant to the
   interpretation of the combined field value, and thus a proxy MUST NOT
   change the order of these field values when a message is forwarded.