### PR TITLE
Fix obsolete gb_tree headers when `Expect: 100-continue`

### DIFF
--- a/src/mochiweb_request.erl
+++ b/src/mochiweb_request.erl
@@ -225,7 +225,7 @@ stream_body(MaxChunkSize, ChunkFun, FunState, MaxBodyLength) ->
              end,
     case Expect of
         "100-continue" ->
-            _ = start_raw_response({100, gb_trees:empty()}),
+            _ = start_raw_response({100, []}),
             ok;
         _Else ->
             ok


### PR DESCRIPTION
```
error:{badrecord,dict}
in function dict:get_slot/2 (dict.erl, line 413)
in call from dict:is_key/2 (dict.erl, line 91)
in call from mochiweb_headers:default/3 (src/mochiweb_headers.erl, line 141)
in call from lists:foldl/3 (lists.erl, line 1263)
in call from mochiweb_request:format_response_header/2 (src/mochiweb_request.erl, line 290)
in call from mochiweb_request:start_raw_response/2 (src/mochiweb_request.erl, line 269)
in call from mochiweb_request:stream_body/5 (src/mochiweb_request.erl, line 228)
```

Was introduced in #10